### PR TITLE
fix: prevent delayed reconnect after termination

### DIFF
--- a/lib/connection/Connection.js
+++ b/lib/connection/Connection.js
@@ -74,7 +74,8 @@ module.exports = (() => {
 		let __paused = false;
 
 		let __reconnectAllowed = false;
-		let __reconnectTimer = null;
+		let __reconnectToken = null;
+		
 		let __pollingFrequency = null;
 
 		let __extendedProfile = false;
@@ -194,9 +195,10 @@ module.exports = (() => {
 
 			__reconnectAllowed = false;
 
-			if (__reconnectTimer) {
-				clearTimeout(__reconnectTimer);
-				__reconnectTimer = null;
+			if (__reconnectToken !== null) {
+				clearTimeout(__reconnectToken);
+				
+				__reconnectToken = null;
 			}
 
 			__loginInfo.mode = null;
@@ -409,11 +411,12 @@ module.exports = (() => {
 
 					const reconnectAction = () => {
 						connect(__loginInfo.hostname, __loginInfo.username, __loginInfo.password, __loginInfo.jwtProvider);
-						__reconnectTimer = null;
+						
+						__reconnectToken = null;
 					};
 					const reconnectDelay = _RECONNECT_INTERVAL + Math.floor(Math.random() * _WATCHDOG_INTERVAL);
 
-					__reconnectTimer = setTimeout(reconnectAction, reconnectDelay);
+					__reconnectToken = setTimeout(reconnectAction, reconnectDelay);
 				}
 			};
 

--- a/lib/connection/Connection.js
+++ b/lib/connection/Connection.js
@@ -74,6 +74,7 @@ module.exports = (() => {
 		let __paused = false;
 
 		let __reconnectAllowed = false;
+		let __reconnectTimer = null;
 		let __pollingFrequency = null;
 
 		let __extendedProfile = false;
@@ -192,6 +193,11 @@ module.exports = (() => {
 			broadcastEvent('events', { event: 'disconnecting' });
 
 			__reconnectAllowed = false;
+
+			if (__reconnectTimer) {
+				clearTimeout(__reconnectTimer);
+				__reconnectTimer = null;
+			}
 
 			__loginInfo.mode = null;
 			__loginInfo.hostname = null;
@@ -401,10 +407,13 @@ module.exports = (() => {
 				if (__reconnectAllowed) {
 					__logger.log(`Connection [ ${__instance} ]: Scheduling reconnect attempt.`);
 
-					const reconnectAction = () => connect(__loginInfo.hostname, __loginInfo.username, __loginInfo.password, __loginInfo.jwtProvider);
+					const reconnectAction = () => {
+						connect(__loginInfo.hostname, __loginInfo.username, __loginInfo.password, __loginInfo.jwtProvider);
+						__reconnectTimer = null;
+					};
 					const reconnectDelay = _RECONNECT_INTERVAL + Math.floor(Math.random() * _WATCHDOG_INTERVAL);
 
-					setTimeout(reconnectAction, reconnectDelay);
+					__reconnectTimer = setTimeout(reconnectAction, reconnectDelay);
 				}
 			};
 

--- a/lib/connection/Connection.js
+++ b/lib/connection/Connection.js
@@ -15,8 +15,6 @@ const DiagnosticsControllerBase = require('./diagnostics/DiagnosticsControllerBa
 
 const LoggerFactory = require('./../logging/LoggerFactory');
 
-const version = require('./../meta').version;
-
 module.exports = (() => {
 	'use strict';
 

--- a/test/specs/utilities/parsers/SymbolParserSpec.js
+++ b/test/specs/utilities/parsers/SymbolParserSpec.js
@@ -2797,13 +2797,13 @@ describe('When checking the display format for the symbol', () => {
 });
 
 describe('When getting a producer symbol', () => {
-	describe('When the year distant (futures expiration in 10 or more years)', () => {
-		it('CLG2034 should map to CLB4', () => {
-			expect(SymbolParser.getProducerSymbol('CLG2034')).toEqual('CLB4');
+	describe('When the year is distant (futures expiration in 10 or more years)', () => {
+		it('CLG2036 should map to CLB6', () => {
+			expect(SymbolParser.getProducerSymbol('CLG2036')).toEqual('CLB6');
 		});
 
-		it('CLG34 should map to CLB4', () => {
-			expect(SymbolParser.getProducerSymbol('CLG34')).toEqual('CLB4');
+		it('CLG36 should map to CLB6', () => {
+			expect(SymbolParser.getProducerSymbol('CLG36')).toEqual('CLB6');
 		});
 
 		it('CLH35 should map to CLC5', () => {


### PR DESCRIPTION
A delayed reconnect timer could still fire after the user logs out or session expires, causing a reconnect attempt with already cleaned-up state. This fix ensures the timer is cleared during termination.

To reproduce:
1. Log in with valid credentials.
2. Close the connection (e.g. disable Wi-Fi).
3. After ~30s, the browser WebSocket drops.
4. Re-enable Wi-Fi to trigger a reconnect attempt.
5. While reconnect is pending, terminate the session (e.g. log out).
6. The reconnect executes with cleaned state and causes an error.